### PR TITLE
Fix drag-drop shadow misalignment for even-sized pieces

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -243,13 +243,10 @@ function calcShadowPlacement(clientX, clientY, piece, bounds) {
     const centerX = clientX;
     const centerY = clientY - DRAG_OFFSET_Y;
 
-    // Which board cell is the piece center over?
-    const boardCol = Math.floor((centerX - boardRect.left) / cellW);
-    const boardRow = Math.floor((centerY - boardRect.top) / cellH);
-
-    // Position piece so it's centered on that cell
-    const targetRow = boardRow - Math.floor((bounds.rows - 1) / 2);
-    const targetCol = boardCol - Math.floor((bounds.cols - 1) / 2);
+    // Find where the floating piece's top-left cell center falls on the board,
+    // matching the continuous centering used by updateFloatingPosition.
+    const targetCol = Math.floor((centerX - boardRect.left) / cellW - (bounds.cols - 1) / 2);
+    const targetRow = Math.floor((centerY - boardRect.top) / cellH - (bounds.rows - 1) / 2);
 
     const result = blokie.tryPlacePiece(state.game_state.game, piece, targetRow, targetCol);
     if (!result) return null;


### PR DESCRIPTION
The shadow calculation snapped the cursor to a board cell first, then
offset by Math.floor((bounds-1)/2) to center. For even-sized pieces
this produced a different result than the floating piece's continuous
centering, causing the shadow to be off by one cell. Combine the
operations into a single Math.floor so the shadow matches the visual.

https://claude.ai/code/session_01Vk6aUrtruk2NYEMPddBZAm