### PR TITLE
Skip rendering empty on-deck area between piece sets

### DIFF
--- a/web/ai-worker.js
+++ b/web/ai-worker.js
@@ -8,6 +8,8 @@ self.onmessage = (e) => {
         if (game_state.queued_game_states.length === 0) {
             if (game_state.piece_set.every(p => blokie.isEmpty(p))) {
                 game_state.piece_set = blokie.getRandomPieceSet();
+                // Show new pieces for one interval before AI starts playing them.
+                return false;
             }
             game_state.queued_game_states = blokie.getAIMove(game_state.game, game_state.piece_set).new_game_states;
             game_state.game.previous_piece_placement = blokie.getEmptyPiece();

--- a/web/ai-worker.js
+++ b/web/ai-worker.js
@@ -8,8 +8,6 @@ self.onmessage = (e) => {
         if (game_state.queued_game_states.length === 0) {
             if (game_state.piece_set.every(p => blokie.isEmpty(p))) {
                 game_state.piece_set = blokie.getRandomPieceSet();
-                // Show new pieces for one interval before AI starts playing them.
-                return false;
             }
             game_state.queued_game_states = blokie.getAIMove(game_state.game, game_state.piece_set).new_game_states;
             game_state.game.previous_piece_placement = blokie.getEmptyPiece();

--- a/web/ai-worker.js
+++ b/web/ai-worker.js
@@ -4,20 +4,17 @@ import { blokie } from "../engine/blokie.js";
 self.onmessage = (e) => {
     const game_state = e.data.game_state;
 
-    // Returns: { is_over, new_piece_set }
     function aiPlayGame() {
         if (game_state.queued_game_states.length === 0) {
-            let new_piece_set = false;
             if (game_state.piece_set.every(p => blokie.isEmpty(p))) {
                 game_state.piece_set = blokie.getRandomPieceSet();
-                new_piece_set = true;
             }
             game_state.queued_game_states = blokie.getAIMove(game_state.game, game_state.piece_set).new_game_states;
             game_state.game.previous_piece_placement = blokie.getEmptyPiece();
-            return { is_over: false, new_piece_set };
+            return false;
         }
         if (blokie.isOver(game_state.queued_game_states[0])) {
-            return { is_over: true, new_piece_set: false };
+            return true;
         }
 
         const new_game_state = game_state.queued_game_states.shift();
@@ -28,43 +25,30 @@ self.onmessage = (e) => {
         }
         game_state.previous_game_state = game_state.game;
         game_state.game = new_game_state;
-        return { is_over: false, new_piece_set: false };
-    }
-
-    function postState() {
-        self.postMessage({
-            game_state: game_state,
-            id: e.data.id,
-        });
+        return false;
     }
 
     if (e.data.delay_ms === 0) {
         // If there is no delay, don't do intervals.
         let is_over = false;
         do {
-            const result = aiPlayGame();
-            is_over = result.is_over;
-            postState();
+            is_over = aiPlayGame();
+            self.postMessage({
+                game_state: game_state,
+                id: e.data.id,
+            });
         } while (!is_over);
         self.close();
     } else {
         setInterval(() => {
-            const result = aiPlayGame();
-            // When a new piece set was generated, post the state showing all
-            // three pieces, then immediately play the first move so there is
-            // no extra interval of dead time.
-            if (result.new_piece_set) {
-                postState();
-                const result2 = aiPlayGame();
-                postState();
-                if (result2.is_over) {
-                    self.close();
-                }
-            } else {
-                postState();
-                if (result.is_over) {
-                    self.close();
-                }
+            const is_over = aiPlayGame();
+            self.postMessage({
+                game_state: game_state,
+                id: e.data.id,
+            });
+
+            if (is_over) {
+                self.close();
             }
         }, e.data.delay_ms);
     }

--- a/web/ai-worker.js
+++ b/web/ai-worker.js
@@ -4,17 +4,20 @@ import { blokie } from "../engine/blokie.js";
 self.onmessage = (e) => {
     const game_state = e.data.game_state;
 
+    // Returns: { is_over, new_piece_set }
     function aiPlayGame() {
         if (game_state.queued_game_states.length === 0) {
+            let new_piece_set = false;
             if (game_state.piece_set.every(p => blokie.isEmpty(p))) {
                 game_state.piece_set = blokie.getRandomPieceSet();
+                new_piece_set = true;
             }
             game_state.queued_game_states = blokie.getAIMove(game_state.game, game_state.piece_set).new_game_states;
             game_state.game.previous_piece_placement = blokie.getEmptyPiece();
-            return false;
+            return { is_over: false, new_piece_set };
         }
         if (blokie.isOver(game_state.queued_game_states[0])) {
-            return true;
+            return { is_over: true, new_piece_set: false };
         }
 
         const new_game_state = game_state.queued_game_states.shift();
@@ -25,30 +28,43 @@ self.onmessage = (e) => {
         }
         game_state.previous_game_state = game_state.game;
         game_state.game = new_game_state;
-        return false;
+        return { is_over: false, new_piece_set: false };
+    }
+
+    function postState() {
+        self.postMessage({
+            game_state: game_state,
+            id: e.data.id,
+        });
     }
 
     if (e.data.delay_ms === 0) {
         // If there is no delay, don't do intervals.
         let is_over = false;
         do {
-            is_over = aiPlayGame();
-            self.postMessage({
-                game_state: game_state,
-                id: e.data.id,
-            });
+            const result = aiPlayGame();
+            is_over = result.is_over;
+            postState();
         } while (!is_over);
         self.close();
     } else {
         setInterval(() => {
-            const is_over = aiPlayGame();
-            self.postMessage({
-                game_state: game_state,
-                id: e.data.id,
-            });
-
-            if (is_over) {
-                self.close();
+            const result = aiPlayGame();
+            // When a new piece set was generated, post the state showing all
+            // three pieces, then immediately play the first move so there is
+            // no extra interval of dead time.
+            if (result.new_piece_set) {
+                postState();
+                const result2 = aiPlayGame();
+                postState();
+                if (result2.is_over) {
+                    self.close();
+                }
+            } else {
+                postState();
+                if (result.is_over) {
+                    self.close();
+                }
             }
         }, e.data.delay_ms);
     }

--- a/web/script.js
+++ b/web/script.js
@@ -446,7 +446,10 @@ function renderImpl() {
 
     if (gameIsActive()) {
         if (state.game_state.queued_game_states.length === 0) {
-            drawGame(board_table, pieces_on_deck_div, state.game_state.game.board, blokie.getEmptyPiece(), state.game_state.piece_set);
+            // When all pieces have been placed, skip rendering the on-deck area
+            // so it keeps showing the previous state instead of flashing empty.
+            const piece_set = state.game_state.piece_set.every(p => blokie.isEmpty(p)) ? null : state.game_state.piece_set;
+            drawGame(board_table, pieces_on_deck_div, state.game_state.game.board, blokie.getEmptyPiece(), piece_set);
             updateScore(state.game_state.game.score);
         } else {
             const next_game_state = state.game_state.queued_game_states[0];
@@ -529,13 +532,15 @@ function drawGame(board_table, pieces_on_deck_div, board, placement, piece_set) 
         }
     }
 
-    for (let i = 0; i < 3; ++i) {
-        const hidePiece = state.dragging_piece_index === i;
-        for (let r = 0; r < 5; ++r) {
-            for (let c = 0; c < 5; ++c) {
-                const td = pieces_on_deck_div.children[i].rows[r].cells[c];
-                const cls = (!hidePiece && blokie.at(piece_set[i], r, c)) ? 'has-piece' : '';
-                if (td.className !== cls) td.className = cls;
+    if (piece_set) {
+        for (let i = 0; i < 3; ++i) {
+            const hidePiece = state.dragging_piece_index === i;
+            for (let r = 0; r < 5; ++r) {
+                for (let c = 0; c < 5; ++c) {
+                    const td = pieces_on_deck_div.children[i].rows[r].cells[c];
+                    const cls = (!hidePiece && blokie.at(piece_set[i], r, c)) ? 'has-piece' : '';
+                    if (td.className !== cls) td.className = cls;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- When all three pieces have been placed, the on-deck area briefly showed all empty slots before the new piece set appeared
- Fix: skip updating the on-deck display when the piece set is all empty, so it retains the previous visual state until the new pieces arrive
- The AI worker delay logic is unchanged — only the rendering is affected

## Details
In `renderImpl`, when `piece_set` is all empty (between sets), pass `null` to `drawGame` instead of the empty set. `drawGame` skips the on-deck update when `piece_set` is `null`, preserving whatever was last displayed.

https://claude.ai/code/session_01EosmSsY3cGnwFUn1ux4Zvd