### PR TITLE
Improve build-wasm.sh setup: add cmake check and fix emsdk path

### DIFF
--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -5,10 +5,16 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BUILD_DIR="$SCRIPT_DIR/engine/cpp/build-wasm"
 OUTPUT_DIR="$SCRIPT_DIR/engine/wasm"
 
+# Install cmake if not available.
+if ! command -v cmake &> /dev/null; then
+    echo "cmake not found, installing..."
+    pip install cmake || { echo "ERROR: Could not install cmake"; exit 1; }
+fi
+
 # Install Emscripten if not available.
 if ! command -v emcmake &> /dev/null; then
     echo "Emscripten not found, installing..."
-    EMSDK_DIR="$SCRIPT_DIR/emsdk"
+    EMSDK_DIR="/tmp/emsdk"
     git clone https://github.com/emscripten-core/emsdk.git "$EMSDK_DIR"
     "$EMSDK_DIR/emsdk" install latest
     "$EMSDK_DIR/emsdk" activate latest


### PR DESCRIPTION
## Summary
Enhanced the WebAssembly build script with better dependency management and improved installation paths.

## Key Changes
- Added automatic cmake installation check before the build process, with error handling if installation fails
- Changed Emscripten SDK (emsdk) installation directory from `$SCRIPT_DIR/emsdk` to `/tmp/emsdk` to avoid cluttering the repository directory with build artifacts

## Implementation Details
- The cmake check follows the same pattern as the existing emcmake check, using `command -v` to detect if the tool is available
- If cmake is not found, it attempts installation via pip with a clear error message on failure
- Moving emsdk to `/tmp` keeps the source repository cleaner while still allowing the build script to function independently

https://claude.ai/code/session_01DKEskCQtGEhuXzQLvyFK2b