### PR TITLE
Generate new pieces immediately after placement instead of delaying

### DIFF
--- a/web/ai-worker.js
+++ b/web/ai-worker.js
@@ -6,11 +6,13 @@ self.onmessage = async (e) => {
 
     const game_state = e.data.game_state;
 
+    let show_new_pieces = false;
+
     function aiPlayGame() {
         if (game_state.queued_game_states.length === 0) {
-            if (game_state.piece_set.every(p => blokie.isEmpty(p))) {
-                game_state.piece_set = blokie.getRandomPieceSet();
+            if (show_new_pieces) {
                 // Show new pieces for one interval before AI starts playing them.
+                show_new_pieces = false;
                 return false;
             }
             game_state.queued_game_states = blokie.getAIMove(game_state.game, game_state.piece_set).new_game_states;
@@ -26,6 +28,11 @@ self.onmessage = async (e) => {
         const used_piece_index = game_state.piece_set.indexOf(piece_used);
         if (used_piece_index >= 0) {
             game_state.piece_set[used_piece_index] = blokie.getEmptyPiece();
+        }
+        // Generate new pieces immediately so the on-deck section is never empty.
+        if (game_state.piece_set.every(p => blokie.isEmpty(p))) {
+            game_state.piece_set = blokie.getRandomPieceSet();
+            show_new_pieces = true;
         }
         game_state.previous_game_state = game_state.game;
         game_state.game = new_game_state;

--- a/web/script.js
+++ b/web/script.js
@@ -318,6 +318,9 @@ function handleDragEnd(clientX, clientY) {
             );
             if (result) {
                 state.game_state.piece_set[drag_info.pieceIndex] = blokie.getEmptyPiece();
+                if (state.game_state.piece_set.every(p => blokie.isEmpty(p))) {
+                    state.game_state.piece_set = blokie.getRandomPieceSet();
+                }
                 state.game_state.previous_game_state = state.game_state.game;
                 state.game_state.game = result.newGame;
                 cleanupDrag();
@@ -474,9 +477,6 @@ function renderImpl() {
 // returns: true if should rerender at max speed
 function aiPlayGame() {
     if (state.game_state.queued_game_states.length === 0) {
-        if (state.game_state.piece_set.every(p => blokie.isEmpty(p))) {
-            state.game_state.piece_set = blokie.getRandomPieceSet();
-        }
         state.game_state.queued_game_states = blokie.getAIMove(state.game_state.game, state.game_state.piece_set).new_game_states;
         state.game_state.game.previous_piece_placement = blokie.getEmptyPiece();
         return false;
@@ -490,6 +490,9 @@ function aiPlayGame() {
     const used_piece_index = state.game_state.piece_set.indexOf(piece_used);
     if (used_piece_index >= 0) {
         state.game_state.piece_set[used_piece_index] = blokie.getEmptyPiece();
+    }
+    if (state.game_state.piece_set.every(p => blokie.isEmpty(p))) {
+        state.game_state.piece_set = blokie.getRandomPieceSet();
     }
     state.game_state.previous_game_state = state.game_state.game;
     state.game_state.game = new_game_state;


### PR DESCRIPTION
## Summary
Refactored the piece generation logic to generate new pieces immediately after a piece is placed, rather than delaying until the next AI move. This ensures the on-deck piece section is never empty and provides better UX.

## Key Changes
- **web/ai-worker.js**: 
  - Moved piece generation from the start of `aiPlayGame()` to after piece placement
  - Introduced `show_new_pieces` flag to display newly generated pieces for one interval before AI uses them
  - Generation now happens immediately when all pieces are empty, rather than waiting for the next AI turn

- **web/script.js**:
  - Added piece generation logic to `handleDragEnd()` so pieces are generated immediately after player placement
  - Removed piece generation from the beginning of `aiPlayGame()`
  - Added piece generation after AI piece placement in `aiPlayGame()`

## Implementation Details
The change ensures that whenever all pieces in the piece set become empty (after either player or AI placement), new pieces are immediately generated. This prevents the on-deck section from ever appearing empty to the player. The AI worker uses a `show_new_pieces` flag to display the newly generated pieces for one render cycle before the AI begins using them, maintaining the intended visual feedback.

https://claude.ai/code/session_01WxMHNogWtEjBuHapZMNwWB