### PR TITLE
Add native benchmark and fitness evaluation tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 engine/cpp/build-wasm/
+engine/cpp/build-native/
 node_modules/
 emsdk/

--- a/engine/cpp/CMakeLists.txt
+++ b/engine/cpp/CMakeLists.txt
@@ -28,4 +28,8 @@ if(EMSCRIPTEN)
 		"SHELL:-s ALLOW_MEMORY_GROWTH=1"
 		"SHELL:-s NO_EXIT_RUNTIME=1"
 	)
+else()
+	# Native build: solver + benchmark driver.
+	add_executable(benchmark benchmark.cpp)
+	target_link_libraries(benchmark PRIVATE solver)
 endif()

--- a/engine/cpp/CMakeLists.txt
+++ b/engine/cpp/CMakeLists.txt
@@ -29,7 +29,12 @@ if(EMSCRIPTEN)
 		"SHELL:-s NO_EXIT_RUNTIME=1"
 	)
 else()
-	# Native build: solver + benchmark driver.
+	# Native build: solver + benchmark/fitness drivers.
+	find_package(Threads REQUIRED)
+
 	add_executable(benchmark benchmark.cpp)
 	target_link_libraries(benchmark PRIVATE solver)
+
+	add_executable(fitness fitness.cpp)
+	target_link_libraries(fitness PRIVATE solver Threads::Threads)
 endif()

--- a/engine/cpp/benchmark.cpp
+++ b/engine/cpp/benchmark.cpp
@@ -1,0 +1,68 @@
+#include "solver.h"
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+// SFC32 RNG - mirrors the sfc32 implementation in engine/blokie.js so
+// piece sequences match between the native benchmark and the JS benchmark.
+struct Sfc32 {
+    uint32_t a, b, c, d;
+    Sfc32(uint32_t a, uint32_t b, uint32_t c, uint32_t d)
+        : a(a), b(b), c(c), d(d) {}
+
+    // Returns a number in [0, 1), matching the JS sfc32 output.
+    double next() {
+        uint32_t t = (a + b) + d;
+        d = d + 1;
+        a = b ^ (b >> 9);
+        b = c + (c << 3);
+        c = (c << 21) | (c >> 11);
+        c = c + t;
+        return (double)t / 4294967296.0;
+    }
+};
+
+static GameState newGame() {
+    return GameState(BitBoard::empty());
+}
+
+int main(int argc, char** argv) {
+    int num_moves = 10000;
+    if (argc > 1) {
+        num_moves = std::atoi(argv[1]);
+        if (num_moves <= 0) {
+            std::fprintf(stderr, "num_moves must be positive\n");
+            return 1;
+        }
+    }
+
+    const auto weights = EvalWeights::getDefault();
+    Sfc32 rng(1, 2, 3, 4);
+
+    GameState game = newGame();
+
+    const auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < num_moves; ++i) {
+        Piece pieces[3];
+        for (int j = 0; j < 3; ++j) {
+            int idx = (int)(rng.next() * Piece::NUM_PIECES);
+            pieces[j] = Piece::byIndex(idx);
+        }
+        PieceSet ps(pieces[0], pieces[1], pieces[2]);
+        game = AI::makeMoveSimple(weights, game, ps);
+        if (game.isOver()) {
+            game = newGame();
+        }
+    }
+    const auto end = std::chrono::steady_clock::now();
+    const double seconds =
+        std::chrono::duration<double>(end - start).count();
+
+    std::printf("%d moves in %.2f seconds (%.0f moves/sec)\n",
+                num_moves, seconds,
+                num_moves / seconds);
+    return 0;
+}

--- a/engine/cpp/fitness.cpp
+++ b/engine/cpp/fitness.cpp
@@ -1,0 +1,118 @@
+#include "solver.h"
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <random>
+#include <thread>
+#include <vector>
+
+namespace {
+
+struct GameResult {
+    uint64_t moves;
+};
+
+GameResult playOneGame(uint64_t seed, const EvalWeights& weights) {
+    // Seeded per-game RNG so results are reproducible regardless of which
+    // thread picks up the game_id.
+    std::mt19937_64 rng(seed);
+    std::uniform_int_distribution<int> piece_dist(0, Piece::NUM_PIECES - 1);
+
+    GameState game(BitBoard::empty());
+    uint64_t moves = 0;
+    while (!game.isOver()) {
+        Piece p0 = Piece::byIndex(piece_dist(rng));
+        Piece p1 = Piece::byIndex(piece_dist(rng));
+        Piece p2 = Piece::byIndex(piece_dist(rng));
+        game = AI::makeMoveSimple(weights, game, PieceSet(p0, p1, p2));
+        ++moves;
+    }
+    return {moves};
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    int num_games = 8;
+    if (argc > 1) {
+        num_games = std::atoi(argv[1]);
+        if (num_games <= 0) {
+            std::fprintf(stderr, "num_games must be positive\n");
+            return 1;
+        }
+    }
+    unsigned hw_threads = std::thread::hardware_concurrency();
+    if (hw_threads == 0) hw_threads = 1;
+    unsigned num_threads = std::min<unsigned>(hw_threads, (unsigned)num_games);
+
+    const auto weights = EvalWeights::getDefault();
+
+    std::atomic<int> next_game_id{0};
+    std::vector<GameResult> results(num_games);
+    std::mutex log_mutex;
+
+    std::fprintf(stderr, "Running %d games across %u threads...\n",
+                 num_games, num_threads);
+
+    const auto start = std::chrono::steady_clock::now();
+
+    std::vector<std::thread> workers;
+    workers.reserve(num_threads);
+    for (unsigned t = 0; t < num_threads; ++t) {
+        workers.emplace_back([&, t]() {
+            while (true) {
+                int id = next_game_id.fetch_add(1, std::memory_order_relaxed);
+                if (id >= num_games) return;
+
+                const auto g_start = std::chrono::steady_clock::now();
+                GameResult r = playOneGame((uint64_t)id + 1, weights);
+                const auto g_end = std::chrono::steady_clock::now();
+                const double g_secs =
+                    std::chrono::duration<double>(g_end - g_start).count();
+
+                results[id] = r;
+                {
+                    std::lock_guard<std::mutex> lk(log_mutex);
+                    std::fprintf(stderr,
+                                 "[t%u] game %d: %llu moves (%.1fs)\n",
+                                 t, id, (unsigned long long)r.moves, g_secs);
+                    std::fflush(stderr);
+                }
+            }
+        });
+    }
+
+    for (auto& w : workers) w.join();
+
+    const auto end = std::chrono::steady_clock::now();
+    const double total_secs =
+        std::chrono::duration<double>(end - start).count();
+
+    // Aggregate stats.
+    double sum = 0.0;
+    double sum_sq = 0.0;
+    uint64_t min_moves = UINT64_MAX;
+    uint64_t max_moves = 0;
+    for (const auto& r : results) {
+        sum += (double)r.moves;
+        sum_sq += (double)r.moves * (double)r.moves;
+        if (r.moves < min_moves) min_moves = r.moves;
+        if (r.moves > max_moves) max_moves = r.moves;
+    }
+    const double mean = sum / num_games;
+    const double var = num_games > 1
+        ? (sum_sq - num_games * mean * mean) / (num_games - 1)
+        : 0.0;
+    const double stddev = std::sqrt(std::max(0.0, var));
+    const double sem = num_games > 1 ? stddev / std::sqrt((double)num_games) : 0.0;
+
+    std::printf("games=%d  mean=%.1f  stddev=%.1f  sem=%.1f  min=%llu  max=%llu  wall=%.1fs\n",
+                num_games, mean, stddev, sem,
+                (unsigned long long)min_moves, (unsigned long long)max_moves,
+                total_secs);
+    return 0;
+}

--- a/engine/cpp/fitness.cpp
+++ b/engine/cpp/fitness.cpp
@@ -1,10 +1,12 @@
 #include "solver.h"
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <mutex>
 #include <random>
 #include <thread>
@@ -13,12 +15,13 @@
 namespace {
 
 struct GameResult {
+    uint64_t seed;
     uint64_t moves;
 };
 
 GameResult playOneGame(uint64_t seed, const EvalWeights& weights) {
-    // Seeded per-game RNG so results are reproducible regardless of which
-    // thread picks up the game_id.
+    // Each game has its own RNG; callers pass a non-deterministic seed by
+    // default. Seeds are reported so any individual game can be reproduced.
     std::mt19937_64 rng(seed);
     std::uniform_int_distribution<int> piece_dist(0, Piece::NUM_PIECES - 1);
 
@@ -31,32 +34,56 @@ GameResult playOneGame(uint64_t seed, const EvalWeights& weights) {
         game = AI::makeMoveSimple(weights, game, PieceSet(p0, p1, p2));
         ++moves;
     }
-    return {moves};
+    return {seed, moves};
+}
+
+double percentile(std::vector<uint64_t> sorted, double p) {
+    if (sorted.empty()) return 0.0;
+    double idx = p * (sorted.size() - 1);
+    size_t lo = (size_t)std::floor(idx);
+    size_t hi = (size_t)std::ceil(idx);
+    double frac = idx - lo;
+    return sorted[lo] * (1.0 - frac) + sorted[hi] * frac;
 }
 
 }  // namespace
 
 int main(int argc, char** argv) {
     int num_games = 8;
-    if (argc > 1) {
-        num_games = std::atoi(argv[1]);
-        if (num_games <= 0) {
-            std::fprintf(stderr, "num_games must be positive\n");
-            return 1;
+    uint64_t seed_base = 0;  // 0 => non-deterministic via random_device
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--seed-base") == 0 && i + 1 < argc) {
+            seed_base = std::strtoull(argv[++i], nullptr, 10);
+        } else {
+            int n = std::atoi(argv[i]);
+            if (n > 0) num_games = n;
         }
     }
+
     unsigned hw_threads = std::thread::hardware_concurrency();
     if (hw_threads == 0) hw_threads = 1;
     unsigned num_threads = std::min<unsigned>(hw_threads, (unsigned)num_games);
 
     const auto weights = EvalWeights::getDefault();
 
+    // Pre-generate per-game seeds so each game's seed is stable.
+    std::vector<uint64_t> seeds(num_games);
+    if (seed_base == 0) {
+        std::random_device rd;
+        for (int i = 0; i < num_games; ++i) {
+            seeds[i] = ((uint64_t)rd() << 32) | rd();
+        }
+    } else {
+        for (int i = 0; i < num_games; ++i) seeds[i] = seed_base + i;
+    }
+
     std::atomic<int> next_game_id{0};
     std::vector<GameResult> results(num_games);
     std::mutex log_mutex;
 
-    std::fprintf(stderr, "Running %d games across %u threads...\n",
-                 num_games, num_threads);
+    std::fprintf(stderr, "Running %d games across %u threads (%s seeds)...\n",
+                 num_games, num_threads,
+                 seed_base == 0 ? "random" : "deterministic");
 
     const auto start = std::chrono::steady_clock::now();
 
@@ -69,7 +96,7 @@ int main(int argc, char** argv) {
                 if (id >= num_games) return;
 
                 const auto g_start = std::chrono::steady_clock::now();
-                GameResult r = playOneGame((uint64_t)id + 1, weights);
+                GameResult r = playOneGame(seeds[id], weights);
                 const auto g_end = std::chrono::steady_clock::now();
                 const double g_secs =
                     std::chrono::duration<double>(g_end - g_start).count();
@@ -78,8 +105,10 @@ int main(int argc, char** argv) {
                 {
                     std::lock_guard<std::mutex> lk(log_mutex);
                     std::fprintf(stderr,
-                                 "[t%u] game %d: %llu moves (%.1fs)\n",
-                                 t, id, (unsigned long long)r.moves, g_secs);
+                                 "[t%u] game %d seed=%llu: %llu moves (%.1fs)\n",
+                                 t, id,
+                                 (unsigned long long)r.seed,
+                                 (unsigned long long)r.moves, g_secs);
                     std::fflush(stderr);
                 }
             }
@@ -93,16 +122,20 @@ int main(int argc, char** argv) {
         std::chrono::duration<double>(end - start).count();
 
     // Aggregate stats.
+    std::vector<uint64_t> moves;
+    moves.reserve(num_games);
     double sum = 0.0;
     double sum_sq = 0.0;
     uint64_t min_moves = UINT64_MAX;
     uint64_t max_moves = 0;
     for (const auto& r : results) {
+        moves.push_back(r.moves);
         sum += (double)r.moves;
         sum_sq += (double)r.moves * (double)r.moves;
         if (r.moves < min_moves) min_moves = r.moves;
         if (r.moves > max_moves) max_moves = r.moves;
     }
+    std::sort(moves.begin(), moves.end());
     const double mean = sum / num_games;
     const double var = num_games > 1
         ? (sum_sq - num_games * mean * mean) / (num_games - 1)
@@ -110,9 +143,20 @@ int main(int argc, char** argv) {
     const double stddev = std::sqrt(std::max(0.0, var));
     const double sem = num_games > 1 ? stddev / std::sqrt((double)num_games) : 0.0;
 
-    std::printf("games=%d  mean=%.1f  stddev=%.1f  sem=%.1f  min=%llu  max=%llu  wall=%.1fs\n",
-                num_games, mean, stddev, sem,
-                (unsigned long long)min_moves, (unsigned long long)max_moves,
-                total_secs);
+    // Raw per-game move counts on stdout so downstream tools can analyze.
+    for (uint64_t m : moves) {
+        std::printf("%llu\n", (unsigned long long)m);
+    }
+
+    std::fprintf(stderr,
+                 "\ngames=%d  mean=%.1f  stddev=%.1f  sem=%.1f\n"
+                 "p25=%.0f  p50=%.0f  p75=%.0f  p90=%.0f  p95=%.0f\n"
+                 "min=%llu  max=%llu  wall=%.1fs\n",
+                 num_games, mean, stddev, sem,
+                 percentile(moves, 0.25), percentile(moves, 0.50),
+                 percentile(moves, 0.75), percentile(moves, 0.90),
+                 percentile(moves, 0.95),
+                 (unsigned long long)min_moves, (unsigned long long)max_moves,
+                 total_secs);
     return 0;
 }


### PR DESCRIPTION
## Summary
This PR adds two new native C++ command-line tools for evaluating the Tetris AI solver: a performance benchmark and a fitness evaluator for testing AI decision quality across multiple games.

## Key Changes
- **benchmark.cpp**: A performance benchmarking tool that measures move execution speed using a deterministic SFC32 RNG (matching the JavaScript implementation for consistency)
- **fitness.cpp**: A multi-threaded fitness evaluator that runs multiple games with the AI solver and reports statistical metrics on game performance (mean, standard deviation, percentiles, min/max move counts)
- **CMakeLists.txt**: Added native build configuration for both tools when not building for WebAssembly, with proper thread library linking for the fitness tool
- **.gitignore**: Added `engine/cpp/build-native/` directory to ignore native build artifacts

## Notable Implementation Details
- The fitness tool uses multi-threaded game execution with atomic operations and mutex-protected logging for thread-safe output
- Both tools support deterministic seeding for reproducible results (fitness uses `--seed-base` flag)
- Fitness evaluator computes comprehensive statistics including mean, standard deviation, standard error of the mean, and percentiles (p25, p50, p75, p90, p95)
- Raw per-game move counts are output to stdout for downstream analysis while summary statistics go to stderr
- The benchmark tool uses the same SFC32 RNG as the JavaScript implementation to ensure piece sequences are identical across platforms

https://claude.ai/code/session_01GGEjmSZrzWiNf7F5sSrnyN